### PR TITLE
feat: Add NO_BROWSER env to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,7 @@
   ],
   
   "remoteEnv": {
-    "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}"
+    "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}",
+    "NO_BROWSER": "true"
   }
 }


### PR DESCRIPTION
Adds the `NO_BROWSER=true` environment variable to the `devcontainer.json` configuration.

This prevents the Gemini CLI from attempting to open a web browser for authentication when running inside the dev container, which would otherwise cause the `gemini auth` command to hang. This allows for a CLI-based authentication flow.