### PR TITLE
This commit refactors the shell scripts to improve modularity and ext…

### DIFF
--- a/scripts/batch_convert.sh
+++ b/scripts/batch_convert.sh
@@ -4,6 +4,8 @@
 
 # 共通関数を読み込み
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/utils.sh"
 source "$SCRIPT_DIR/split_and_convert.sh"
 
 # 設定
@@ -68,7 +70,7 @@ convert_file_auto() {
 $content"
         
         # Geminiで変換実行
-        if gemini -p "$prompt" > "$output_file" 2>> "$LOG_FILE"; then
+        if gemini_wrapper "$prompt" "$output_file"; then
             if [ -s "$output_file" ]; then
                 log "成功: $filename"
                 return 0
@@ -116,6 +118,9 @@ if [ $large_count -gt 0 ]; then
     echo -e "${BLUE}  ※ ${large_count}個の大容量ファイルは自動的に分割処理されます${NC}"
 fi
 echo ""
+
+# 変換時間の予測を表示
+estimate_conversion_time "simple" "${input_files[@]}"
 
 # バッチ処理
 batch_count=$(( (total_files + BATCH_SIZE - 1) / BATCH_SIZE ))

--- a/scripts/split_and_convert.sh
+++ b/scripts/split_and_convert.sh
@@ -2,24 +2,16 @@
 
 # Gemini Corpus Builder - 分割変換共通関数
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/utils.sh"
+
 # 設定
 TEMP_DIR="temp_chunks"
 MAX_FILE_SIZE=${MAX_FILE_SIZE:-50000}  # 50KB以上を大きいファイルとする
 CHUNK_SIZE=${CHUNK_SIZE:-30000}        # 30KB単位で分割
 CHUNK_DELAY=${CHUNK_DELAY:-1}          # チャンク間の遅延
 
-# ファイルサイズをチェック
-check_file_size() {
-    local file=$1
-    stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null
-}
-
-# ファイルが大容量かチェック
-is_large_file() {
-    local file=$1
-    local size=$(check_file_size "$file")
-    [ "$size" -gt "$MAX_FILE_SIZE" ]
-}
 
 # テキストを段落で分割
 split_by_paragraphs() {

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# Gemini Corpus Builder - 共通ユーティリティ関数
+
+# ログ関数 (呼び出し元のスクリプトで定義されていることを想定)
+# log() { ... }
+
+# ファイルサイズをチェック
+check_file_size() {
+    local file=$1
+    # statコマンドの互換性対応
+    stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null
+}
+
+# ファイルが大容量かチェック
+is_large_file() {
+    local file=$1
+    local size
+    size=$(check_file_size "$file")
+    # MAX_FILE_SIZEは呼び出し元で定義されていることを想定
+    [ "$size" -gt "${MAX_FILE_SIZE:-50000}" ]
+}
+
+# ファイル名をサニタイズする関数
+sanitize_filename() {
+    # スラッシュ、ヌル文字、その他制御文字を削除
+    # スペースと特殊文字をアンダースコアに置換
+    # 連続するアンダースコアを一つにまとめる
+    # 先頭と末尾のアンダースコアを削除
+    echo "$1" | tr -d '/\0' | tr '[:space:][:punct:]' '_' | sed 's/__*/_/g' | sed 's/^_//;s/_$//'
+}
+
+# Geminiコマンドのラッパー関数（ロギング対応）
+gemini_wrapper() {
+    local prompt="$1"
+    local output_file="${2:-}" # 出力ファイルは任意
+
+    if [ "${LOG_LEVEL}" == "debug" ]; then
+        log "--- Gemini Prompt ---
+$prompt
+---------------------"
+    fi
+
+    local response
+    if response=$(gemini -p "$prompt" 2>> "$LOG_FILE"); then
+        if [ "${LOG_LEVEL}" == "debug" ]; then
+            log "--- Gemini Response ---
+$response
+-----------------------"
+        fi
+
+        if [ -n "$output_file" ]; then
+            echo "$response" > "$output_file"
+        else
+            echo "$response"
+        fi
+        return 0
+    else
+        log "エラー: Geminiコマンドの実行に失敗しました。"
+        response="GEMINI_COMMAND_FAILED"
+        return 1
+    fi
+}
+export -f gemini_wrapper
+
+# 変換されたテキストからファイル名を生成する関数
+generate_filename_from_content() {
+    local content_file=$1
+    local max_chars=1000
+
+    local truncated_content=$(head -c $max_chars "$content_file")
+
+    local prompt="以下のテキスト内容を、ファイル名として適切な30文字程度の日本語の要約にしてください。句読点や特殊文字は含めず、簡潔な表現でお願いします。要約のみを出力してください。
+
+テキスト：
+$truncated_content
+"
+    local summary
+    summary=$(gemini_wrapper "$prompt")
+
+    sanitize_filename "$summary"
+}
+
+# 変換時間の予測
+estimate_conversion_time() {
+    local mode=$1
+    shift
+    local files=("$@")
+    local total_files=${#files[@]}
+    local total_chunks=0
+    local normal_files=0
+    local large_files=0
+
+    local avg_conversion_api_time=8
+    local avg_summary_api_time=3
+
+    for file in "${files[@]}"; do
+        if is_large_file "$file";
+        then
+            ((large_files++))
+            local size
+            size=$(check_file_size "$file")
+            local chunks=$(( (size + CHUNK_SIZE - 1) / CHUNK_SIZE ))
+            ((total_chunks += chunks))
+        else
+            ((normal_files++))
+        fi
+    done
+
+    local api_delay=${API_DELAY:-0.5}
+    local chunk_delay=${CHUNK_DELAY:-1}
+
+    local summary_time_per_file=$avg_summary_api_time
+    # 'consistency' モード以外では要約時間をゼロにする
+    if [ "$mode" != "consistency" ]; then
+        summary_time_per_file=0
+    fi
+
+    local normal_time_float=$(echo "$normal_files * ($avg_conversion_api_time + $summary_time_per_file) + $normal_files * $api_delay" | bc)
+    local large_time_float=$(echo "$total_chunks * ($avg_conversion_api_time + $chunk_delay) + $large_files * $summary_time_per_file" | bc)
+    local total_seconds_float=$(echo "$normal_time_float + $large_time_float" | bc)
+
+    local total_seconds=${total_seconds_float%.*}
+
+    local minutes=$(( total_seconds / 60 ))
+    local seconds=$(( total_seconds % 60 ))
+
+    echo "---"
+    echo -e "${BLUE}予測変換時間: 約 ${minutes} 分 ${seconds} 秒${NC}"
+    echo "  (通常ファイル: $normal_files, 大容量ファイル: $large_files, 総チャンク数: $total_chunks)"
+    echo "  ※ これはあくまで目安です。ネットワークの状態やAPIの応答速度によって変動します。"
+    echo "---"
+}


### PR DESCRIPTION
…ends the visibility features to the `make convert` command.

Changes include:
1.  **Created `scripts/utils.sh`:** Common helper functions (`check_file_size`, `is_large_file`, `gemini_wrapper`, `estimate_conversion_time`, etc.) have been moved into a new `utils.sh` script.
2.  **Updated Script Sourcing:** `consistency_manager.sh`, `split_and_convert.sh`, and `batch_convert.sh` now source this common utility script.
3.  **Extended Time Estimation:** The `estimate_conversion_time` function is now also used in `batch_convert.sh`, providing a time estimate for the `make convert` command. The function was updated to support different modes for more accurate estimation.
4.  **Extended Debug Logging:** The `gemini` call in `batch_convert.sh` was replaced with the `gemini_wrapper`, enabling debug logging for the `make convert` command as well.