### PR TITLE
refactor(auth): Switch to Google login for authentication

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,8 +36,5 @@
     "source=${localWorkspaceFolder}/output,target=/workspace/output,type=bind"
   ],
   
-  "remoteEnv": {
-    "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}",
-    "NO_BROWSER": "true"
-  }
+  "remoteEnv": {}
 }


### PR DESCRIPTION
Removes the `GEMINI_API_KEY` environment variable from the dev container configuration.

By removing the API key, the `gemini-cli` will now default to the interactive "Login with Google" browser-based authentication flow, as you requested.

This change aligns with the project's setup instructions, which mention authenticating via the `gemini` command.