### PR TITLE
I have fixed an issue where Gemini CLI authentication would not persi…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,8 @@
   
   "mounts": [
     "source=${localWorkspaceFolder}/input,target=/workspace/input,type=bind",
-    "source=${localWorkspaceFolder}/output,target=/workspace/output,type=bind"
+    "source=${localWorkspaceFolder}/output,target=/workspace/output,type=bind",
+    "source=${localEnv:HOME}/.gemini,target=${containerEnv:HOME}/.gemini,type=bind"
   ],
   
   "remoteEnv": {}


### PR DESCRIPTION
…st across Dev Container sessions.

The problem was that the authentication token, stored in the `~/.gemini` directory, was being saved inside the container's ephemeral filesystem. When the container was rebuilt, this token was lost, forcing you to re-authenticate.

I fixed this by modifying the `.devcontainer/devcontainer.json` file to mount your local `~/.gemini` directory into the container. This ensures that the authentication token is stored on your host machine and is available every time the container is started.

I added the following line to the `mounts` array in `.devcontainer/devcontainer.json`:

`"source=${localEnv:HOME}/.gemini,target=${containerEnv:HOME}/.gemini,type=bind"`

This will make the authentication process seamless for you when working within the Dev Container.