### PR TITLE
This change corrects the target path for the `.gemini` directory moun…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
   "mounts": [
     "source=${localWorkspaceFolder}/input,target=/workspace/input,type=bind",
     "source=${localWorkspaceFolder}/output,target=/workspace/output,type=bind",
-    "source=${localEnv:HOME}/.gemini,target=${containerEnv:HOME}/.gemini,type=bind"
+    "source=${localEnv:HOME}/.gemini,target=/home/node/.gemini,type=bind"
   ],
   
   "remoteEnv": {}


### PR DESCRIPTION
…t in the `.devcontainer/devcontainer.json` file.

The previous attempt used `${containerEnv:HOME}` as the target, which is not a valid variable in the mount configuration. This caused an error when building the dev container.

This commit replaces the invalid path with the correct, absolute path `/home/node/.gemini`, which is the home directory for the default `node` user in the container. This ensures the mount is configured correctly and that Gemini CLI authentication will be persisted across container sessions.