### PR TITLE
fix(devcontainer): Use node image to resolve user creation error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Gemini Corpus Builder Dev Container",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
   
   "postCreateCommand": "npm install -g @google/gemini-cli && make setup",
   
@@ -23,9 +23,6 @@
   
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "lts"
-    },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.11"
     }


### PR DESCRIPTION
The dev container was failing to start because the 'node' user did not exist. This was caused by using a minimal base ubuntu image and adding the node feature on top of it.

I changed the base image to 'mcr.microsoft.com/devcontainers/javascript-node:18', which comes with a 'node' user pre-configured.

I also removed the now-redundant 'node' feature from the configuration.