### PR TITLE
fix(devcontainer): Upgrade node to v20 to fix gemini-cli error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Gemini Corpus Builder Dev Container",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
   
   "postCreateCommand": "npm install -g @google/gemini-cli && make setup",
   


### PR DESCRIPTION
The 'make auth' command was failing with a 'ReferenceError: File is not defined' from a dependency of @google/gemini-cli.

This error is caused by an incompatibility between the 'undici' package and Node.js v18.

Upgraded the dev container's Node.js version from 18 to 20. Node.js 20 has better support for the 'File' API, which should resolve the error.