### PR TITLE
fix(auth): Update gemini cli command to fix login error

### DIFF
--- a/scripts/setup_auth.sh
+++ b/scripts/setup_auth.sh
@@ -61,7 +61,7 @@ echo ""
 export GEMINI_AUTH_TIMEOUT=300  # 5分
 
 # 認証コマンド実行
-if gemini auth login; then
+if gemini auth; then
     echo ""
     echo -e "${GREEN}認証が完了しました！${NC}"
     echo ""


### PR DESCRIPTION
The 'make auth' command was failing with an 'Unknown argument: login' error. This is because the 'gemini login' and 'gemini auth login' commands are no longer supported in the version of @google/gemini-cli being used.

I updated the authentication script at 'scripts/setup_auth.sh' to use the new 'gemini auth' command.