### PR TITLE
fix(auth): devcontainer内のgemini auth権限エラーを修正

### DIFF
--- a/scripts/setup_auth.sh
+++ b/scripts/setup_auth.sh
@@ -12,6 +12,13 @@ NC='\033[0m'
 echo -e "${BLUE}=== Gemini CLI 認証セットアップ ===${NC}"
 echo ""
 
+# コンテナ内の.geminiディレクトリの権限を調整
+# devcontainerでマウントされたディレクトリはroot所有になることがあるため、現在のユーザーに所有権を移譲する
+if [ -d "$HOME/.gemini" ]; then
+    # echo "Adjusting permissions for $HOME/.gemini..."
+    sudo chown -R "$(id -u):$(id -g)" "$HOME/.gemini"
+fi
+
 # Gemini CLIがインストールされているか確認
 if ! command -v gemini &> /dev/null; then
     echo -e "${RED}エラー: Gemini CLIがインストールされていません${NC}"


### PR DESCRIPTION
devcontainer環境で `make auth` を実行した際に発生する権限エラーを修正します。

原因:
devcontainerがホストの `~/.gemini` をコンテナ内の `/home/node/.gemini` にマウントする際、コンテナ内の `node` ユーザーに書き込み権限がないことが原因でした。`gemini auth` コマンドがテレメトリー用のIDファイルを作成しようとして失敗していました。

修正:
`scripts/setup_auth.sh` スクリプトの冒頭で、`sudo chown` を使用して `/home/node/.gemini` ディレクトリの所有権を現在のコンテナユーザーに変更する処理を追加しました。これにより、`gemini auth` コマンドが正常にファイルを書き込めるようになります。